### PR TITLE
Exclude master branch from Release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: Release
 on:
   push:
-    branches:  [master]
     tags:
     - "[0-9]+"
     - "[0-9]+.[0-9]+"

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,6 @@
 # Changelog for subcategories
 
-## 0.2.0.2
+## 0.2.1.0
 
 * Supports GHC 9.8
 * Drops support for GHC <9

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: subcategories
-version: 0.2.1.1
+version: 0.2.1.0
 github: "konn/subcategories"
 license: BSD3
 author: "Hiromi ISHII"

--- a/package.yaml
+++ b/package.yaml
@@ -4,7 +4,7 @@ github: "konn/subcategories"
 license: BSD3
 author: "Hiromi ISHII"
 maintainer: "konn.jinro _at_ gmail.com"
-copyright: "2018 (c) Hiromi ISHII"
+copyright: "2023 (c) Hiromi ISHII"
 
 tested-with: |
   GHC ==9.0.2 || ==9.2.8 || ==9.4.8 || ==9.6.3 || ==9.8.1

--- a/subcategories.cabal
+++ b/subcategories.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 25884a994f30eee1fbbc1b615d8bbee1086fc4d8a2b1eaf053f3a3f8030594ef
+-- hash: 577fff015a41b96b344a0a7a41284117ea91e94d37c79e486db43bee07113db1
 
 name:           subcategories
-version:        0.2.1.1
+version:        0.2.1.0
 synopsis:       Subcategories induced by class constraints
 description:    Please see the README on GitHub at <https://github.com/konn/subcategories#readme>
 category:       Data

--- a/subcategories.cabal
+++ b/subcategories.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 4df898b4744451dde35e9edf90e639e5ee6699b965221f4f6c054e31ff46f118
+-- hash: 25884a994f30eee1fbbc1b615d8bbee1086fc4d8a2b1eaf053f3a3f8030594ef
 
 name:           subcategories
 version:        0.2.1.1
@@ -15,7 +15,7 @@ homepage:       https://github.com/konn/subcategories#readme
 bug-reports:    https://github.com/konn/subcategories/issues
 author:         Hiromi ISHII
 maintainer:     konn.jinro _at_ gmail.com
-copyright:      2018 (c) Hiromi ISHII
+copyright:      2023 (c) Hiromi ISHII
 license:        BSD3
 license-file:   LICENSE
 tested-with:


### PR DESCRIPTION
Removes accidentally enabled `master` condition from Release action trigger